### PR TITLE
Sync CFBundleName with CFBundleDisplayName for iOS

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -47,7 +47,8 @@ class Utils {
     keys.removeWhere((element) => element is XmlText);
     for (int i = 0; i < keys.length; i++) {
       /// Will be true if google is already configured
-      if (keys[i].innerText == 'CFBundleDisplayName') {
+      if (keys[i].innerText == 'CFBundleDisplayName' ||
+          keys[i].innerText == 'CFBundleName') {
         var value = XmlElement(XmlName('string'));
         value.innerText = appName;
         keys.removeAt(i + 1);


### PR DESCRIPTION
This fix changes the value of **CFBundleName** to always match **CFBundleDisplayName** in the **Info.plist** file. This helps the IPA exported having the name same with app name on phone screen.

Before this PR being merged. You guys can use my folk temporarily.
```
rename_app: 
    git:
      url: https://github.com/nhan7777/rename_app.git
      ref: master
```