### PR TITLE
Use updated linux runner path introduced in flutter 3.27.0

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -15,5 +15,5 @@ const iosReleasePlistPath = "ios/Runner/Info-Release.plist";
 const webManifestPath = "web/manifest.json";
 /// File path of windows/runner/main.cpp for windows.
 const windowsMainCppPath = "windows/runner/main.cpp";
-/// File path of linux/my_application.cc for linux.
-const linuxApplicationPath = "linux/my_application.cc";
+/// File path of linux/runner/my_application.cc for linux.
+const linuxApplicationPath = "linux/runner/my_application.cc";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: rename_app
 description: The flutter package which changes app name for all platforms with sound null safety!
-version: 1.6.3
+version: 2.0.0
 homepage: null
 repository: https://github.com/Syed-Waleed-Shah/rename_app
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:
@@ -17,4 +17,3 @@ dev_dependencies:
   flutter_lints: ^2.0.3
 
 flutter: null
-


### PR DESCRIPTION
Addresses #15

This pull request changes the `linuxApplicationPath` from `"linux/my_application.cc"` to `"linux/runner/my_application.cc"`, matching the new Linux runner path.

This request might need more work, discussion, and review, since I assume this would be a breaking change (unless the path change has been backported). I made the following updates to the environment that are likely required:  

- Upgrade (dart) sdk: `">=2.12.0 <4.0.0"` to `">=3.0.0 <4.0.0"`  
- Upgrade flutter `">=1.17.0"` to `">=3.27.0"`

I tried avoiding a breaking change, and considered switching the expected linux path based on the flutter version, but there doesn't currently seem to be a good way to programmatically get the Flutter SDK version during runtime. I found this package, [dart_flutter_version](https://pub.dev/documentation/dart_flutter_version/latest/), that attempts to do that, but it requires (dart) sdk `">=2.17.0"` and flutter `">=3.0.0"`, which introduces the same issue of only supporting flutter `">=3.x.x"` and above, up from flutter `">=1.17.0"`. Also see the sections on [Flutter Version Resolution](https://pub.dev/documentation/dart_flutter_version/latest/#flutter-version-resolution) and [Accuracy Considerations](https://pub.dev/documentation/dart_flutter_version/latest/#accuracy-considerations) that are of concern.

---

Pending your decision on how to proceed. I'm not too familiar with dart, flutter and the pub.dev package repository; although, I can't imagine it being too difficult to employ semantic versioning properly, and to manage separate releases accordingly. I would be willing to look into that if necessary.
