### PR TITLE
Use updated linux runner path and fallback to legacy path

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -15,5 +15,7 @@ const iosReleasePlistPath = "ios/Runner/Info-Release.plist";
 const webManifestPath = "web/manifest.json";
 /// File path of windows/runner/main.cpp for windows.
 const windowsMainCppPath = "windows/runner/main.cpp";
-/// File path of linux/my_application.cc for linux.
-const linuxApplicationPath = "linux/my_application.cc";
+/// File path of linux/runner/my_application.cc for linux.
+const linuxApplicationPath = "linux/runner/my_application.cc";
+/// Old file path of linux/my_application.cc for linux before flutter 2.37.0.
+const legacyLinuxApplicationPath = "linux/my_application.cc";

--- a/lib/rename_app.dart
+++ b/lib/rename_app.dart
@@ -63,8 +63,13 @@ class RenameApp {
   }
 
   static Future<void> linux(String linux) async {
-    if (await Utils.fileNotExists(linuxApplicationPath)) {
-      Utils.printNoConfigFound('linux');
+    var path = linuxApplicationPath;
+    
+    if (await Utils.fileNotExists(path)) {
+      path = legacyLinuxApplicationPath;
+      if (await Utils.fileNotExists(path)) {
+        Utils.printNoConfigFound('linux');
+      }
       return;
     }
 
@@ -72,6 +77,6 @@ class RenameApp {
       return;
     }
 
-    await Utils.renameLinux(linuxApplicationPath, linux);
+    await Utils.renameLinux(path, linux);
   }
 }


### PR DESCRIPTION
Addresses #15

This introduces another constant, `legacyLinuxApplicationPath`, to handle trying the old, pre-3.27.0 linux runner path if the new one fails.

Not well tested. I ran this branch on my current flutter environment, and it seems to be working:

```bash
$ flutter --version
Flutter 3.32.4 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 6fba2447e9 (2 weeks ago) • 2025-06-12 19:03:56 -0700
Engine • revision 8cd19e509d (2 weeks ago) • 2025-06-12 16:30:12 -0700
Tools • Dart 3.8.1 • DevTools 2.45.1

$ dart run rename_app:main all="Test"
Building package executable... 
Built rename_app:main.
📱 Android App Name: Test
📱 IOS App Name: Test
💻 Web App Name: Test
💻 Windows App Name: Test
💻 Linux App Name: Test


✅ FINISHED RENAMING [ANDROID] PROJECT

✅ FINISHED RENAMING [IOS] PROJECT

✅ FINISHED RENAMING [WEB] PROJECT

✅ FINISHED RENAMING [WINDOWS] PROJECT

✅ FINISHED RENAMING [LINUX] PROJECT

--------------------------------
✅  RENAMED APPS SUCCESSFULLY!
--------------------------------
```