### PR TITLE
Add support for config_name in pubspec.yaml

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,8 +1,11 @@
 library rename_app;
 
+import 'dart:io';
+
 import 'package:rename_app/constants.dart';
 import 'package:rename_app/rename_app.dart';
 import 'package:rename_app/utils.dart';
+import 'package:yaml/yaml.dart';
 
 String? android;
 String? ios;
@@ -12,8 +15,29 @@ String? windows;
 String? linux;
 void main(List<String> arguments) async {
   if (arguments.isEmpty) {
-    Utils.logMessage(help);
-    return;
+    final pubspecFile = File('pubspec.yaml');
+
+    if (pubspecFile.existsSync()) {
+      try {
+        final content = pubspecFile.readAsStringSync();
+        final yamlMap = loadYaml(content);
+
+        final configName = yamlMap['config_name']?['name'];
+        if (configName != null && configName is String) {
+          Utils.logMessage("Using config_name from pubspec.yaml: $configName");
+          arguments = ['all=$configName'];
+        } else {
+          Utils.logMessage(help);
+          return;
+        }
+      } catch (e) {
+        Utils.logMessage(help);
+        return;
+      }
+    } else {
+      Utils.logMessage(help);
+      return;
+    }
   }
   parseArguments(arguments);
   Utils.logMessage('📱 Android App Name: $android');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   xml: ^6.5.0
+  yaml: ^3.1.3
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
This PR adds support for reading app name from pubspec.yaml using config_name.

### Changes:
- Reads `config_name.name` from pubspec.yaml
- Automatically applies it when no CLI arguments are provided
- Falls back to existing behavior if not defined

### Example:
config_name:
  name: "My App"

Run:
dart run rename_app:main

Closes #18